### PR TITLE
Update flash_portapack_mayhem.bat to include portapack-h1_h2-mayhem.b…

### DIFF
--- a/flashing/flash_portapack_mayhem.bat
+++ b/flashing/flash_portapack_mayhem.bat
@@ -10,8 +10,19 @@ echo.
 pause
 
 echo.
+
+REM Check if the firmware file exists
+if not exist portapack-h1_h2-mayhem.bin (
+    echo The firmware file "portapack-h1_h2-mayhem.bin" does not exist.
+    echo Please ensure that you have downloaded the latest release from:
+    echo https://github.com/eried/portapack-mayhem/releases/
+    echo.
+    pause
+    exit /b
+)
+
 hackrf_update.exe portapack-h1_h2-mayhem.bin
 echo.
-echo If your device never boot after flashing, please refer to https://github.com/eried/portapack-mayhem/wiki/Won't-boot
+echo If your device never boots after flashing, please refer to https://github.com/eried/portapack-mayhem/wiki/Won't-boot
 echo.
 pause


### PR DESCRIPTION
…in check - _wfopen:8007002 remediation

The current version of flash_portapack_mayhem.bat lacks a check to ensure that the necessary firmware file, "portapack-h1_h2-mayhem.bin," exists. This omission can lead to the _wfopen:8007002 error when users download the script from the main code base, where the firmware file is not included. 

The updated script includes a check to verify the presence of "portapack-h1_h2-mayhem.bin" before proceeding with the firmware update. If the file is missing, it displays a helpful message directing users to download the latest release from the following URL: https://github.com/eried/portapack-mayhem/releases/. This addition will prevent users from encountering the _wfopen:8007002 error caused by downloading from the main code base.

Thank you for considering this update to ensure a smoother user experience.

-- Chat GPT Generated, because why not. :)